### PR TITLE
feat: add ADR for Google OAuth authentication strategy

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -157,3 +157,28 @@ Accepted
   reconnect handling, scaling, and monitoring
 - Neutral: requires team familiarity with event-driven patterns while existing
   REST endpoints continue to be used where appropriate
+
+## ADR 7: Authentication with Google OAuth
+
+**Context**
+
+The project currently uses Google OAuth for authentication, but the team is evaluating whether to keep that setup or move to a different authentication approach. A major concern is testability: a custom provider would be easier to control and mock in Playwright than Google OAuth.
+
+**Decision**
+
+The current implementation uses Google OAuth for sign-in, and the backend creates and refreshes application sessions after a successful login. The long-term authentication strategy is still under review, with better automated testability as one of the key decision factors.
+
+**Status**
+
+Pending
+
+**Consequences**
+
+- Positive: reduces custom security work compared with a fully self-managed
+  credential flow.
+- Positive: a custom provider would be easier to mock in Playwright-based end-
+  to-end tests.
+- Negative: continuing with Google keeps the auth flow dependent on an
+  external service and makes browser automation harder to isolate.
+- Neutral: the backend still manages application sessions and authorization
+  for protected routes.


### PR DESCRIPTION
This pull request adds a new architectural decision record (ADR) documenting the current and future considerations for authentication in the project. The ADR outlines the use of Google OAuth, the reasoning behind the choice, and the trade-offs involved, especially regarding testability and dependency on external services.

Authentication strategy documentation:

* Added ADR 7 to `docs/decisions.md`, describing the current use of Google OAuth for authentication, the ongoing evaluation of alternative approaches, and the implications for testability and dependency on external providers.